### PR TITLE
Make "Share" and "Close" buttons translatable

### DIFF
--- a/widgets/views/editor.php
+++ b/widgets/views/editor.php
@@ -26,9 +26,9 @@ if ($documentType === Module::DOCUMENT_TYPE_SPREADSHEET) {
 <div style = "height:50px; border-radius: 8px 8px 0px 0px; background-color:<?= $headerBackgroundColor; ?>; padding-top:6px; padding-right:12px">
     <div class = "pull-right" style = "margin-top:8px;margin-right:12px">
         <?php if ($mode === Module::OPEN_MODE_EDIT && !Yii::$app->user->isGuest): ?>
-            <?= humhub\libs\Html::a('Share', '#', ['class' => 'btn btn btn-default', 'data-action-click' => 'share', 'data-action-block' => 'sync', 'data-action-url' => Url::to(['/onlydocuments/share', 'guid' => $file->guid, 'mode' => $mode])]); ?>
+            <?= humhub\libs\Html::a(Yii::t('OnlydocumentsModule.base', 'Share'), '#', ['class' => 'btn btn btn-default', 'data-action-click' => 'share', 'data-action-block' => 'sync', 'data-action-url' => Url::to(['/onlydocuments/share', 'guid' => $file->guid, 'mode' => $mode])]); ?>
         <?php endif; ?>
-        <?= humhub\libs\Html::a('Close', '#', ['class' => 'btn btn btn-default', 'data-ui-loader' => '', 'data-action-click' => 'close', 'data-action-block' => 'manual']); ?>
+        <?= humhub\libs\Html::a(Yii::t('OnlydocumentsModule.base', 'Close'), '#', ['class' => 'btn btn btn-default', 'data-ui-loader' => '', 'data-action-click' => 'close', 'data-action-block' => 'manual']); ?>
     </div>
     <div style="color:white;padding-left:12px;font-size:24px;padding-top:3px;padding-left:18px"><?= $headerTitle; ?></div>
 </div>


### PR DESCRIPTION
In the OnlyOffice Editor overlay, the two buttons "Share" and "Close" at the top right corner can now be translated.