### PR TITLE
Fix display of user name

### DIFF
--- a/resources/humhub.onlydocuments.js
+++ b/resources/humhub.onlydocuments.js
@@ -108,6 +108,7 @@ humhub.module('onlydocuments', function (module, require, $) {
                 callbackUrl: this.options.backendTrackUrl,
                 user: {
                     id: this.options.userGuid,
+                    name: this.options.userName,
                     firstname: this.options.userFirstName,
                     lastname: this.options.userLastName,
                 },

--- a/widgets/EditorWidget.php
+++ b/widgets/EditorWidget.php
@@ -80,6 +80,7 @@ class EditorWidget extends JsWidget
             'created-at' => Html::encode('Creator AT'),
             'document-type' => $this->documentType,
             'user-guid' => ($user) ? Html::encode($user->guid) : '',
+            'user-name' => ($user) ? Html::encode($user->displayName) : 'Anonymous',
             'user-first-name' => ($user) ? Html::encode($user->profile->firstname) : 'Anonymous',
             'user-last-name' => ($user) ? Html::encode($user->profile->lastname) : 'User',
             'user-language' => ($user) ? $user->language : 'en',


### PR DESCRIPTION
Editor config parameters user.firstname and user.lastname are
deprecated since ONLYOFFICE Document Server version 4.2; add new
parameter user.name to prevent display of user name as "Anonymous".